### PR TITLE
Fix issue when missing URL for datasheet

### DIFF
--- a/partdetails.py
+++ b/partdetails.py
@@ -166,19 +166,25 @@ class PartDetailsDialog(wx.Dialog):
 
     def savepdf(self, *_):
         """Download a datasheet from The LCSC API."""
-        filename = self.pdfurl.rsplit("/", maxsplit=1)[1]
-        self.logger.info("Save datasheet %s to %s", filename, self.datasheet_path)
-        self.datasheet_path.mkdir(parents=True, exist_ok=True)
-        result = self.lcsc_api.download_datasheet(
-            self.pdfurl, self.datasheet_path / filename
-        )
-        title = "Success" if result["success"] else "Error"
-        style = "info" if result["success"] else "error"
+        if self.pdfurl != None:
+           filename = self.pdfurl.rsplit("/", maxsplit=1)[1]
+           self.logger.info("Save datasheet %s to %s", filename, self.datasheet_path)
+           self.datasheet_path.mkdir(parents=True, exist_ok=True)
+           result = self.lcsc_api.download_datasheet(
+               self.pdfurl, self.datasheet_path / filename
+           )
+           title = "Success" if result["success"] else "Error"
+           style = "info" if result["success"] else "error"
+           resultMsg = result["msg"]
+        else:
+            title = "Error"
+            style = "error"
+            resultMsg = "Undefined URL for datasheet download"
         wx.PostEvent(
             self.parent,
             MessageEvent(
                 title=title,
-                text=result["msg"],
+                text=resultMsg,
                 style=style,
             ),
         )


### PR DESCRIPTION
When URL is missing there is a crash in the plugin leading to need to kill Kicad